### PR TITLE
Update soln19.py

### DIFF
--- a/soln19.py
+++ b/soln19.py
@@ -1,44 +1,31 @@
 # Write a Python class to find validity of a string of parentheses, '(', ')', '{', '}', '[' and ']. 
 # These brackets must be close in the correct order, for example "()" and "()[]{}" are valid but "[)", "({[)]" and "{{{" are invalid 
 
+class ParenthesisValidator:
+	stack = []
 
-class ParenthesesValidity:
-    count_small_open_parentheses = 0
-    count_small_close_parentheses = 0
-    count_curly_open_parentheses = 0
-    count_curly_close_parentheses = 0
-    count_large_open_parentheses = 0
-    count_large_close_parentheses = 0
+	def __init__(self, inputString):
+		self.validationString = inputString
+
+	def runValidator(self):
+		for character in self.validationString:
+			if character in [ "{", "(", "["]:
+				self.stack.append(character)
+			elif character == "]" and self.stack.pop() != "[":
+				return False
+			elif character == "}" and self.stack.pop() != "{":
+				return False
+			elif character == ")" and self.stack.pop() != "(":
+				return False
+			else :
+				return False
+		if len(self.stack) > 0 :
+			return False
+		return True
 
 
-    def __init__(self, parentheses_string):
-        self.parentheses_string  = parentheses_string
-    
-    def count_parentheses(self):        
-        for char in self.parentheses_string:
-            if (char == '('):
-                self.count_small_open_parentheses += 1
-            elif (char == ')'):
-                self.count_small_close_parentheses += 1
-            elif (char == '{'):
-                self.count_curly_open_parentheses += 1
-            elif (char == '}'):
-                self.count_curly_close_parentheses += 1
-            elif (char == '['):
-                self.count_large_open_parentheses += 1
-            elif (char == ']'):
-                self.count_large_close_parentheses += 1
-            else:
-                continue
-
-    def check_validity(self):
-        if(self.count_small_open_parentheses == self.count_small_close_parentheses 
-        and self.count_curly_open_parentheses == self.count_curly_close_parentheses 
-        and self.count_large_open_parentheses == self.count_large_close_parentheses):
-            print("valid parentheses string")
-        else:
-            print("invalid parentheses string")
-
-class_obj = ParenthesesValidity("()[]{[}")
-class_obj.count_parentheses()
-class_obj.check_validity()
+object = ParenthesisValidator("{{[()]}}")
+if object.runValidator():
+	print("valid bracket sequence")
+else:
+	print("not a valid bracket sequence")


### PR DESCRIPTION
using a stack would more accurately solve the problem,

 the sequence of brackets, can also appear in the incorrect order while closing, but may have equal number of them:

e.g.,
[ { ] }

as the question states, the brackets should be closed in the correct sequence.
The final if condition to check the length of the array would also make sure that there are no pending opening brackets left.

This is assuming that no other characters other than the brackets are inserted in the query string.
To handle extra characters, one can either change the if condition, and move the and condition inside the and conditions, 
or use a pre-emptive filter and remove all the unwanted characters, before the processing starts.